### PR TITLE
Deprecate vite-plugin-hash-csp

### DIFF
--- a/packages/vite-plugin-hash-csp/README.md
+++ b/packages/vite-plugin-hash-csp/README.md
@@ -1,6 +1,6 @@
 # Vite Plugin Hash CSP
 
-This is a well tested Vite Plugin that allows you to declare your Content Security Policy (CSP) for your Vite project. First class support for SPA's
+This is has moved to [vite-plugin-csp-guard]()
 
 ## Documentation
 

--- a/packages/vite-plugin-hash-csp/README.md
+++ b/packages/vite-plugin-hash-csp/README.md
@@ -1,6 +1,6 @@
 # Vite Plugin Hash CSP
 
-This is has moved to [vite-plugin-csp-guard]()
+## This package has **moved** to [vite-plugin-csp-guard](https://www.npmjs.com/package/vite-plugin-csp-guard)
 
 ## Documentation
 

--- a/packages/vite-plugin-hash-csp/package.json
+++ b/packages/vite-plugin-hash-csp/package.json
@@ -12,11 +12,11 @@
   "homepage": "https://vite-csp.tsotne.co.uk",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/RockiRider/vite-plugin-hash-csp",
+    "url": "git+https://github.com/RockiRider/csp",
     "directory": "packages/vite-plugin-hash-csp"
   },
   "bugs": {
-    "url": "https://github.com/RockiRider/vite-plugin-hash-csp/issues"
+    "url": "https://github.com/RockiRider/csp/issues"
   },
   "license": "GPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/vite-plugin-hash-csp/package.json
+++ b/packages/vite-plugin-hash-csp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-hash-csp",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": {
     "name": "Tsotne Gvadzabia"
   },


### PR DESCRIPTION
# Deprecate Vite-plugin-hash-csp
Need to switch the name up because hashing seems kind of irrelevant for builds.

## Key Changes

- Updated Readme preparing for deprecation
- Updated links to the new repo

## Approach <!-- Optional -->

## Checklist

- [ ] Tests
- [ ] Documentation
