### PR TITLE
Don't quote "blob:" in CSP

### DIFF
--- a/packages/vite-plugin-csp-guard/src/policy/createPolicy.ts
+++ b/packages/vite-plugin-csp-guard/src/policy/createPolicy.ts
@@ -9,7 +9,7 @@ const createPolicy = (policy: CSPPolicy): string => {
       .map((v) => {
         // Check if the value starts with "sha" and enclose it in single quotes if it does.
         // Also enclose in single quotes if it matches other specified conditions.
-        if (v.startsWith("sha") || v === "*" || v === "blob:") return `'${v}'`;
+        if (v.startsWith("sha") || v === "*") return `'${v}'`;
         else return v;
       })
       .join(" ");


### PR DESCRIPTION
Hi, thanks for creating this plugin. I ran into a problem using it and loading a worker from a `blob:` url. I think this line is incorrect:

https://github.com/RockiRider/csp/blob/aa1ea7abb82e28afafbe0f7bfb1138a4031d0c82/packages/vite-plugin-csp-guard/src/policy/createPolicy.ts#L12

According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#scheme-source `blob:` should not be surrounded in quotes.