### PR TITLE
chore(release): bump vite-plugin-csp-guard to v3.0.0

### DIFF
--- a/packages/vite-plugin-csp-guard/package.json
+++ b/packages/vite-plugin-csp-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-csp-guard",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "author": {
     "name": "Tsotne Gvadzabia"
   },


### PR DESCRIPTION
# Key Changes

- Supports Vite 7
- Drops all older Vite versions for support
- Drops CJS support

## Approach <!-- Optional -->

## Checklist

- [ ] Tests
- [ ] Documentation
