### PR TITLE
feat: support Vite 8

### DIFF
--- a/packages/vite-plugin-csp-guard/package.json
+++ b/packages/vite-plugin-csp-guard/package.json
@@ -31,7 +31,7 @@
   "typings": "dist/index.d.ts",
   "type": "module",
   "peerDependencies": {
-    "vite": "^7.0.0"
+    "vite": "^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:^",

--- a/packages/vite-plugin-csp-guard/src/css/index.ts
+++ b/packages/vite-plugin-csp-guard/src/css/index.ts
@@ -1,4 +1,4 @@
-import { ModuleInfo } from "rollup";
+import type { ModuleInfo } from "rollup";
 import { walk } from "estree-walker";
 import { type Program, Node } from "estree";
 

--- a/packages/vite-plugin-csp-guard/src/index.ts
+++ b/packages/vite-plugin-csp-guard/src/index.ts
@@ -1,5 +1,5 @@
 import { Plugin, ViteDevServer } from "vite";
-import { PluginContext } from "rollup";
+import type { ModuleInfo, PluginContext } from "rollup";
 import {
   CSPPluginContext,
   MyPluginOptions,
@@ -89,11 +89,14 @@ export default function vitePluginCSP(
     name: "vite-plugin-csp-guard",
     enforce: "post",
     buildStart() {
-      pluginContext = this;
+      // Cast via `unknown`: Vite 8 types `this` as Rolldown's (narrower) PluginContext,
+      // while Vite 7 types it as Rollup's. The plugin only uses the value as an opaque
+      // pass-through, so the cast is safe under both versions.
+      pluginContext = this as unknown as PluginContext;
       viteVersion = this.meta.viteVersion;
       if (!viteVersion) {
         throw new Error(
-          "Please ensure your using a minimum version of vite 7.0.0."
+          "Please ensure you're using a minimum version of vite 7.0.0."
         );
       }
     },
@@ -195,8 +198,12 @@ export default function vitePluginCSP(
       }
     },
     moduleParsed: (info) =>
-      // This handleModuleParsed function is not ready for production
-      features.cssInJs ? unstable_handleModuleParsed({ info }) : undefined,
+      // This handleModuleParsed function is not ready for production.
+      // Cast via `unknown`: Vite 8 types `info` as Rolldown's (narrower) ModuleInfo;
+      // only `info.id` and `info.ast` are consumed downstream, both present in both shapes.
+      features.cssInJs
+        ? unstable_handleModuleParsed({ info: info as unknown as ModuleInfo })
+        : undefined,
     configureServer(thisServer) {
       server = thisServer;
     },

--- a/packages/vite-plugin-csp-guard/src/transform/handleIndexHtml.ts
+++ b/packages/vite-plugin-csp-guard/src/transform/handleIndexHtml.ts
@@ -5,7 +5,7 @@ import {
   HashCollection,
 } from "../types";
 import { addHash, generateHash, warnMissingPolicy } from "../policy/core";
-import { PluginContext } from "rollup";
+import type { PluginContext } from "rollup";
 import { extractAssetPath } from "../utils";
 import { CSPPolicy } from "csp-toolkit";
 

--- a/packages/vite-plugin-csp-guard/src/transform/index.ts
+++ b/packages/vite-plugin-csp-guard/src/transform/index.ts
@@ -1,8 +1,8 @@
-import { IndexHtmlTransformContext, ViteDevServer } from "vite";
+import type { IndexHtmlTransformContext, ViteDevServer } from "vite";
+import type { OutputBundle, PluginContext } from "rollup";
 import { addHash, generateHash } from "../policy/core";
 import { BundleContext, TransformationStatus } from "../types";
 import { handleCSPInsert, handleIndexHtml } from "./handleIndexHtml";
-import { PluginContext } from "rollup";
 import { generatePolicyString } from "../policy/createPolicy";
 import { cssFilter, jsFilter, preCssFilter, tsFilter } from "../utils";
 import { getCSS } from "../css/extraction";
@@ -154,7 +154,12 @@ export const transformIndexHtmlHandler = ({
               );
             }
             if (requirements.strongLazyLoading) {
-              code = replaceVueRouterPreload(code, bundle);
+              // Cast via `unknown`: Vite 8 types `bundle` as Rolldown's (narrower)
+              // OutputBundle; we only use chunk metadata that exists in both shapes.
+              code = replaceVueRouterPreload(
+                code,
+                bundle as unknown as OutputBundle
+              );
             } else {
               code = replaceVitePreload(code);
             }

--- a/packages/vite-plugin-csp-guard/src/transform/lazy.ts
+++ b/packages/vite-plugin-csp-guard/src/transform/lazy.ts
@@ -1,4 +1,11 @@
-import { OutputBundle, OutputChunk } from "rollup";
+import type { OutputBundle, OutputChunk } from "rollup";
+import type { ChunkMetadata } from "vite";
+
+// Vite augments chunk output with `viteMetadata`. In Vite 7 the augmentation
+// targets rollup's `OutputChunk`; in Vite 8 the module hooks were redirected to
+// rolldown's types, so rollup's `OutputChunk` no longer picks it up. Intersect
+// with the vite-exported `ChunkMetadata` so the access typechecks under both.
+type ViteOutputChunk = OutputChunk & { viteMetadata?: ChunkMetadata };
 
 export const replaceVitePreload = (code: string) => {
   return code.replace(/__VITE_PRELOAD__/g, "[]");
@@ -25,7 +32,8 @@ export const generateViteDepMap = (bundle: OutputBundle) => {
   for (const importPath of indexChunk.dynamicImports) {
     // Find the corresponding chunk in the bundle
     const chunk = Object.values(bundle).find(
-      (c): c is OutputChunk => c.type === "chunk" && c.fileName === importPath
+      (c): c is ViteOutputChunk =>
+        c.type === "chunk" && c.fileName === importPath
     );
 
     if (!chunk) continue;

--- a/packages/vite-plugin-csp-guard/src/types.ts
+++ b/packages/vite-plugin-csp-guard/src/types.ts
@@ -1,5 +1,5 @@
 import { CSPKeys, CSPPolicy } from "csp-toolkit";
-import { PluginContext } from "rollup";
+import type { PluginContext } from "rollup";
 
 export type HashAlgorithms = "sha256" | "sha384" | "sha512";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     vite:
-      specifier: ^7.1.3
-      version: 7.1.3
+      specifier: ^8.0.1
+      version: 8.0.8
 
 importers:
 
@@ -40,7 +40,7 @@ importers:
         version: 5.9.2
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@20.19.11)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@20.19.11)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -126,7 +126,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+        version: 4.7.0(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -138,7 +138,7 @@ importers:
         version: 0.4.20(eslint@8.57.1)
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vite-plugin-csp-guard:
         specifier: workspace:^
         version: link:../../packages/vite-plugin-csp-guard
@@ -175,7 +175,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+        version: 4.7.0(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -190,7 +190,7 @@ importers:
         version: 4.4.1
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vite-plugin-csp-guard:
         specifier: workspace:^
         version: link:../../packages/vite-plugin-csp-guard
@@ -233,7 +233,7 @@ importers:
         version: 18.3.7(@types/react@18.3.23)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+        version: 4.7.0(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -245,7 +245,7 @@ importers:
         version: 0.4.20(eslint@8.57.1)
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vite-plugin-csp-guard:
         specifier: workspace:^
         version: link:../../packages/vite-plugin-csp-guard
@@ -258,7 +258,7 @@ importers:
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.8.3
-        version: 2.10.2(@babel/core@7.28.3)(preact@10.27.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+        version: 2.10.2(@babel/core@7.28.3)(preact@10.27.1)(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
       '@repo/testing':
         specifier: workspace:^
         version: link:../../packages/testing
@@ -267,7 +267,7 @@ importers:
         version: link:../../packages/typescript-config
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vite-plugin-csp-guard:
         specifier: workspace:^
         version: link:../../packages/vite-plugin-csp-guard
@@ -304,7 +304,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+        version: 4.7.0(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -316,7 +316,7 @@ importers:
         version: 0.4.20(eslint@8.57.1)
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vite-plugin-csp-guard:
         specifier: workspace:^
         version: link:../../packages/vite-plugin-csp-guard
@@ -334,7 +334,7 @@ importers:
         version: 2.17.0(typescript@5.9.2)
       '@tailwindcss/vite':
         specifier: ^4.0.9
-        version: 4.1.12(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+        version: 4.1.12(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
       isbot:
         specifier: ^4.1.0
         version: 4.4.0
@@ -350,7 +350,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.16.0
-        version: 2.17.0(@remix-run/react@2.17.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(@remix-run/serve@2.17.0(typescript@5.9.2))(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2))(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))(yaml@2.8.1)
+        version: 2.17.0(@remix-run/react@2.17.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(@remix-run/serve@2.17.0(typescript@5.9.2))(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2))(typescript@5.9.2)(vite@8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))(yaml@2.8.1)
       '@repo/testing':
         specifier: workspace:^
         version: link:../../packages/testing
@@ -395,13 +395,13 @@ importers:
         version: 8.5.6
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vite-plugin-csp-guard:
         specifier: workspace:^
         version: link:../../packages/vite-plugin-csp-guard
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+        version: 4.3.2(typescript@5.9.2)(vite@8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
 
   apps/scss:
     dependencies:
@@ -432,7 +432,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+        version: 4.7.0(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -447,7 +447,7 @@ importers:
         version: 1.90.0
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vite-plugin-csp-guard:
         specifier: workspace:^
         version: link:../../packages/vite-plugin-csp-guard
@@ -466,13 +466,13 @@ importers:
         version: link:../../packages/typescript-config
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vite-plugin-csp-guard:
         specifier: workspace:^
         version: link:../../packages/vite-plugin-csp-guard
       vite-plugin-solid:
         specifier: ^2.10.2
-        version: 2.11.8(solid-js@1.9.9)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+        version: 2.11.8(solid-js@1.9.9)(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
 
   apps/stylus:
     dependencies:
@@ -506,7 +506,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.63.0)(terser@5.37.0)(yaml@2.8.1))
+        version: 4.7.0(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.63.0)(terser@5.37.0)(yaml@2.8.1))
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -521,7 +521,7 @@ importers:
         version: 0.63.0
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.63.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.63.0)(terser@5.37.0)(yaml@2.8.1)
       vite-plugin-csp-guard:
         specifier: workspace:^
         version: link:../../packages/vite-plugin-csp-guard
@@ -536,7 +536,7 @@ importers:
         version: link:../../packages/typescript-config
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.1
-        version: 3.1.2(svelte@4.2.20)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+        version: 3.1.2(svelte@4.2.20)(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.4
@@ -545,13 +545,13 @@ importers:
         version: 4.2.20
       svelte-check:
         specifier: ^4.1.1
-        version: 4.3.1(picomatch@4.0.3)(svelte@4.2.20)(typescript@5.9.2)
+        version: 4.3.1(picomatch@4.0.4)(svelte@4.2.20)(typescript@5.9.2)
       tslib:
         specifier: ^2.6.3
         version: 2.8.1
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vite-plugin-csp-guard:
         specifier: workspace:^
         version: link:../../packages/vite-plugin-csp-guard
@@ -588,7 +588,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+        version: 4.7.0(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.21(postcss@8.5.6)
@@ -609,7 +609,7 @@ importers:
         version: 3.4.17(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2))
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vite-plugin-csp-guard:
         specifier: workspace:^
         version: link:../../packages/vite-plugin-csp-guard
@@ -621,7 +621,7 @@ importers:
         version: link:../../packages/eslint-config
       '@tailwindcss/vite':
         specifier: ^4.0.9
-        version: 4.1.12(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+        version: 4.1.12(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -652,10 +652,10 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+        version: 4.7.0(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
       autoprefixer:
         specifier: ^10.4.19
-        version: 10.4.21(postcss@8.5.6)
+        version: 10.4.21(postcss@8.5.10)
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -667,7 +667,7 @@ importers:
         version: 0.4.20(eslint@8.57.1)
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vite-plugin-csp-guard:
         specifier: workspace:^
         version: link:../../packages/vite-plugin-csp-guard
@@ -686,10 +686,10 @@ importers:
         version: link:../../packages/testing
       '@vitejs/plugin-vue':
         specifier: ^5.2.1
-        version: 5.2.4(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
+        version: 5.2.4(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vite-plugin-csp-guard:
         specifier: workspace:^
         version: link:../../packages/vite-plugin-csp-guard
@@ -717,7 +717,7 @@ importers:
         version: link:../../packages/typescript-config
       '@vitejs/plugin-vue':
         specifier: ^5.2.1
-        version: 5.2.4(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))(vue@3.5.19(typescript@5.7.3))
+        version: 5.2.4(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))(vue@3.5.19(typescript@5.7.3))
       '@vue/tsconfig':
         specifier: ^0.7.0
         version: 0.7.0(typescript@5.7.3)(vue@3.5.19(typescript@5.7.3))
@@ -726,7 +726,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vite-plugin-csp-guard:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-csp-guard
@@ -823,10 +823,10 @@ importers:
         version: 4.47.1
       vite:
         specifier: 'catalog:'
-        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+        version: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.1(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)
+        version: 1.6.1(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)
 
 packages:
 
@@ -1123,6 +1123,15 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -2062,6 +2071,12 @@ packages:
     resolution: {integrity: sha512-jMxvwzkKzd3cXo2EB9GM2ic0eYo2rP/BS6gJt6HnWbsDO1O8GSD4k7o2Cpr2YERtMpGF/MGcDfsfj2EbQPtrXw==}
     engines: {node: '>= 10'}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@13.5.8':
     resolution: {integrity: sha512-YmiG58BqyZ2FjrF2+5uZExL2BrLr8RTQzLXNDJ8pJr0O+rPlOeDPXp1p1/4OrR3avDidzZo3D8QO2cuDv1KCkw==}
 
@@ -2159,6 +2174,9 @@ packages:
   '@npmcli/promise-spawn@6.0.2':
     resolution: {integrity: sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
   '@parcel/watcher-android-arm64@2.5.0':
     resolution: {integrity: sha512-qlX4eS28bUcQCdribHkg/herLe+0A9RyYC+mm2PXpncit8z5b3nSqGVzMNR3CmtAOgRutiZ02eIJJgP/b1iEFQ==}
@@ -2365,8 +2383,100 @@ packages:
   '@remix-run/web-stream@1.1.0':
     resolution: {integrity: sha512-KRJtwrjRV5Bb+pM7zxcTJkhIqWWSy+MYsIxHK+0m5atcznsf15YwUBWHWulZerV2+vvHH1Lp1DD7pw6qKW8SgA==}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rolldown/pluginutils@1.0.0-rc.15':
+    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
   '@rollup/plugin-commonjs@26.0.3':
     resolution: {integrity: sha512-2BJcolt43MY+y5Tz47djHkodCC3c1VKVrBDKpVqHKpQ9z9S158kCCqB8NF6/gzxLdNlYW9abB3Ibh+kOWLp8KQ==}
@@ -2683,6 +2793,9 @@ packages:
   '@turbo/workspaces@2.5.6':
     resolution: {integrity: sha512-TmY25GmxzgX+395Fwl/F0te6S4RHdJtYl1QjZr+wlxVvKJ0IBOACpnpAvnLM3dpTgXuQukGtSWcRz7Zi9mZqcQ==}
     hasBin: true
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
@@ -5429,8 +5542,20 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.30.1:
     resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -5441,8 +5566,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.30.1:
     resolution: {integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -5453,8 +5590,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.30.1:
     resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -5465,8 +5614,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -5477,8 +5638,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -5489,8 +5662,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.30.1:
     resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
@@ -6370,6 +6553,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
@@ -6486,6 +6673,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
@@ -6797,6 +6988,11 @@ packages:
 
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
+
+  rolldown@1.0.0-rc.15:
+    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   rollup@4.47.1:
     resolution: {integrity: sha512-iasGAQoZ5dWDzULEUX3jiW0oB1qyFOepSyDyoU6S/OhVlDIwj5knI5QBa5RRQ0sK7OE0v+8VIi2JuV+G+3tfNg==}
@@ -7320,6 +7516,10 @@ packages:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
   tinygradient@1.1.5:
     resolution: {integrity: sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==}
 
@@ -7794,6 +7994,49 @@ packages:
       less:
         optional: true
       lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@8.0.8:
+    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
         optional: true
       sass:
         optional: true
@@ -8447,6 +8690,22 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
@@ -9153,6 +9412,13 @@ snapshots:
       '@napi-rs/simple-git-win32-arm64-msvc': 0.1.19
       '@napi-rs/simple-git-win32-x64-msvc': 0.1.19
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@next/env@13.5.8': {}
 
   '@next/env@14.2.32': {}
@@ -9239,6 +9505,8 @@ snapshots:
     dependencies:
       which: 3.0.1
 
+  '@oxc-project/types@0.124.0': {}
+
   '@parcel/watcher-android-arm64@2.5.0':
     optional: true
 
@@ -9311,17 +9579,17 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@preact/preset-vite@2.10.2(@babel/core@7.28.3)(preact@10.27.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))':
+  '@preact/preset-vite@2.10.2(@babel/core@7.28.3)(preact@10.27.1)(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/plugin-transform-react-jsx': 7.25.9(@babel/core@7.28.3)
       '@babel/plugin-transform-react-jsx-development': 7.25.9(@babel/core@7.28.3)
-      '@prefresh/vite': 2.4.6(preact@10.27.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+      '@prefresh/vite': 2.4.6(preact@10.27.1)(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
       '@rollup/pluginutils': 4.2.1
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.28.3)
       debug: 4.4.0
       picocolors: 1.1.1
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+      vite: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vite-prerender-plugin: 0.5.6
     transitivePeerDependencies:
       - preact
@@ -9335,7 +9603,7 @@ snapshots:
 
   '@prefresh/utils@1.2.0': {}
 
-  '@prefresh/vite@2.4.6(preact@10.27.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))':
+  '@prefresh/vite@2.4.6(preact@10.27.1)(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.3
       '@prefresh/babel-plugin': 0.5.1
@@ -9343,11 +9611,11 @@ snapshots:
       '@prefresh/utils': 1.2.0
       '@rollup/pluginutils': 4.2.1
       preact: 10.27.1
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+      vite: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@remix-run/dev@2.17.0(@remix-run/react@2.17.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(@remix-run/serve@2.17.0(typescript@5.9.2))(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2))(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))(yaml@2.8.1)':
+  '@remix-run/dev@2.17.0(@remix-run/react@2.17.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(@remix-run/serve@2.17.0(typescript@5.9.2))(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2))(typescript@5.9.2)(vite@8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))(yaml@2.8.1)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/generator': 7.26.9
@@ -9364,7 +9632,7 @@ snapshots:
       '@remix-run/router': 1.23.0
       '@remix-run/server-runtime': 2.17.0(typescript@5.9.2)
       '@types/mdx': 2.0.13
-      '@vanilla-extract/integration': 6.5.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)
+      '@vanilla-extract/integration': 6.5.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)
       arg: 5.0.2
       cacache: 17.1.4
       chalk: 4.1.2
@@ -9404,12 +9672,12 @@ snapshots:
       tar-fs: 2.1.3
       tsconfig-paths: 4.2.0
       valibot: 0.41.0(typescript@5.9.2)
-      vite-node: 3.2.4(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       ws: 7.5.10
     optionalDependencies:
       '@remix-run/serve': 2.17.0(typescript@5.9.2)
       typescript: 5.9.2
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+      vite: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9516,7 +9784,58 @@ snapshots:
     dependencies:
       web-streams-polyfill: 3.3.3
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.15': {}
 
   '@rollup/plugin-commonjs@26.0.3(rollup@4.47.1)':
     dependencies:
@@ -9635,26 +9954,26 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)))(svelte@4.2.20)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)))(svelte@4.2.20)(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.20)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+      '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.20)(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
       debug: 4.4.1
       svelte: 4.2.20
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+      vite: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))':
+  '@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)))(svelte@4.2.20)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)))(svelte@4.2.20)(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
       debug: 4.4.1
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 4.2.20
       svelte-hmr: 0.16.0(svelte@4.2.20)
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
-      vitefu: 0.2.5(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+      vite: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+      vitefu: 0.2.5(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -9729,12 +10048,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.12
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.12
 
-  '@tailwindcss/vite@4.1.12(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))':
+  '@tailwindcss/vite@4.1.12(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))':
     dependencies:
       '@tailwindcss/node': 4.1.12
       '@tailwindcss/oxide': 4.1.12
       tailwindcss: 4.1.12
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+      vite: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
 
   '@tanstack/react-virtual@3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9802,6 +10121,11 @@ snapshots:
       picocolors: 1.0.1
       semver: 7.6.2
       update-check: 1.5.4
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/acorn@4.0.6':
     dependencies:
@@ -10302,7 +10626,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@vanilla-extract/integration@6.5.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)':
+  '@vanilla-extract/integration@6.5.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.9)
@@ -10315,8 +10639,8 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.7.4
       outdent: 0.8.0
-      vite: 5.4.19(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)
-      vite-node: 1.6.1(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)
+      vite: 5.4.19(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)
+      vite-node: 1.6.1(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -10362,7 +10686,7 @@ snapshots:
       - jest
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.63.0)(terser@5.37.0)(yaml@2.8.1))':
+  '@vitejs/plugin-react@4.7.0(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.63.0)(terser@5.37.0)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.3)
@@ -10370,11 +10694,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.63.0)(terser@5.37.0)(yaml@2.8.1)
+      vite: 8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.63.0)(terser@5.37.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))':
+  '@vitejs/plugin-react@4.7.0(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.3)
@@ -10382,18 +10706,18 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+      vite: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.4(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))(vue@3.5.19(typescript@5.7.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))(vue@3.5.19(typescript@5.7.3))':
     dependencies:
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+      vite: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vue: 3.5.19(typescript@5.7.3)
 
-  '@vitejs/plugin-vue@5.2.4(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))':
+  '@vitejs/plugin-vue@5.2.4(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))':
     dependencies:
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+      vite: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
       vue: 3.5.19(typescript@5.9.2)
 
   '@vitest/expect@1.6.1':
@@ -10718,6 +11042,16 @@ snapshots:
       tslib: 2.8.1
 
   astring@1.9.0: {}
+
+  autoprefixer@10.4.21(postcss@8.5.10):
+    dependencies:
+      browserslist: 4.25.3
+      caniuse-lite: 1.0.30001736
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.1.1
+      postcss: 8.5.10
+      postcss-value-parser: 4.2.0
 
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
@@ -12583,13 +12917,17 @@ snapshots:
     dependencies:
       format: 0.2.2
 
-  fdir@6.4.2(picomatch@4.0.3):
+  fdir@6.4.2(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   figures@3.2.0:
     dependencies:
@@ -13506,34 +13844,67 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.30.1:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.30.1:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.30.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.1:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.1:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.1:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.30.1:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.30.1:
@@ -13550,6 +13921,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.1
       lightningcss-win32-arm64-msvc: 1.30.1
       lightningcss-win32-x64-msvc: 1.30.1
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.0.4
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@3.1.3: {}
 
@@ -14785,6 +15172,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pidtree@0.6.0: {}
 
   pify@2.3.0: {}
@@ -14887,6 +15276,12 @@ snapshots:
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -15264,6 +15659,27 @@ snapshots:
       glob: 7.2.3
 
   robust-predicates@3.0.2: {}
+
+  rolldown@1.0.0-rc.15:
+    dependencies:
+      '@oxc-project/types': 0.124.0
+      '@rolldown/pluginutils': 1.0.0-rc.15
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
   rollup@4.47.1:
     dependencies:
@@ -15777,11 +16193,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.3.1(picomatch@4.0.3)(svelte@4.2.20)(typescript@5.9.2):
+  svelte-check@4.3.1(picomatch@4.0.4)(svelte@4.2.20)(typescript@5.9.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.3
-      fdir: 6.4.2(picomatch@4.0.3)
+      fdir: 6.4.2(picomatch@4.0.4)
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 4.2.20
@@ -15916,6 +16332,11 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinygradient@1.1.5:
     dependencies:
@@ -16342,13 +16763,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@1.6.1(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0):
+  vite-node@1.6.1(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.19(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)
+      vite: 5.4.19(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -16360,13 +16781,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.2.4(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -16381,7 +16802,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-solid@2.11.8(solid-js@1.9.9)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)):
+  vite-plugin-solid@2.11.8(solid-js@1.9.9)(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)):
     dependencies:
       '@babel/core': 7.26.0
       '@types/babel__core': 7.20.5
@@ -16389,8 +16810,8 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.9
       solid-refresh: 0.6.3(solid-js@1.9.9)
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
-      vitefu: 1.0.4(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
+      vite: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+      vitefu: 1.0.4(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -16402,18 +16823,18 @@ snapshots:
       source-map: 0.7.4
       stack-trace: 1.0.0-pre2
 
-  vite-tsconfig-paths@4.3.2(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)):
+  vite-tsconfig-paths@4.3.2(typescript@5.9.2)(vite@8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.4(typescript@5.9.2)
     optionalDependencies:
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+      vite: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.4.19(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0):
+  vite@5.4.19(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -16422,77 +16843,91 @@ snapshots:
       '@types/node': 24.3.0
       fsevents: 2.3.3
       less: 4.4.1
-      lightningcss: 1.30.1
+      lightningcss: 1.32.0
       sass: 1.90.0
       stylus: 0.64.0
       terser: 5.37.0
 
-  vite@7.1.3(@types/node@20.19.11)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1):
+  vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.0
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
       rollup: 4.47.1
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.3.0
+      fsevents: 2.3.3
+      jiti: 2.5.1
+      less: 4.4.1
+      lightningcss: 1.32.0
+      sass: 1.90.0
+      stylus: 0.64.0
+      terser: 5.37.0
+      yaml: 2.8.1
+
+  vite@8.0.8(@types/node@20.19.11)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 20.19.11
       fsevents: 2.3.3
       jiti: 2.5.1
       less: 4.4.1
-      lightningcss: 1.30.1
       sass: 1.90.0
       stylus: 0.64.0
       terser: 5.37.0
       yaml: 2.8.1
 
-  vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.63.0)(terser@5.37.0)(yaml@2.8.1):
+  vite@8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1):
     dependencies:
-      esbuild: 0.25.0
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.47.1
-      tinyglobby: 0.2.14
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.3.0
+      esbuild: 0.17.6
+      fsevents: 2.3.3
+      jiti: 2.5.1
+      less: 4.4.1
+      sass: 1.90.0
+      stylus: 0.64.0
+      terser: 5.37.0
+      yaml: 2.8.1
+
+  vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.63.0)(terser@5.37.0)(yaml@2.8.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 24.3.0
       fsevents: 2.3.3
       jiti: 2.5.1
       less: 4.4.1
-      lightningcss: 1.30.1
       sass: 1.90.0
       stylus: 0.63.0
       terser: 5.37.0
       yaml: 2.8.1
 
-  vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1):
-    dependencies:
-      esbuild: 0.25.0
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.47.1
-      tinyglobby: 0.2.14
+  vitefu@0.2.5(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)):
     optionalDependencies:
-      '@types/node': 24.3.0
-      fsevents: 2.3.3
-      jiti: 2.5.1
-      less: 4.4.1
-      lightningcss: 1.30.1
-      sass: 1.90.0
-      stylus: 0.64.0
-      terser: 5.37.0
-      yaml: 2.8.1
+      vite: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
 
-  vitefu@0.2.5(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)):
+  vitefu@1.0.4(vite@8.0.8(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)):
     optionalDependencies:
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
+      vite: 8.0.8(@types/node@24.3.0)(esbuild@0.17.6)(jiti@2.5.1)(less@4.4.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
 
-  vitefu@1.0.4(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)):
-    optionalDependencies:
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)(yaml@2.8.1)
-
-  vitest@1.6.1(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0):
+  vitest@1.6.1(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -16511,8 +16946,8 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.19(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)
-      vite-node: 1.6.1(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.30.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)
+      vite: 5.4.19(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)
+      vite-node: 1.6.1(@types/node@24.3.0)(less@4.4.1)(lightningcss@1.32.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.37.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,6 @@ packages:
   - "apps/*"
 
 catalog:
-  vite: ^7.1.3
+  vite: ^8.0.1
   typescript: ^5.5.2
   eslint: ^8.57.0


### PR DESCRIPTION
Closes #342

## Summary

Adds Vite 8 support while keeping Vite 7 compatible. Widens the peer range to `^7.0.0 || ^8.0.0` and adapts the plugin's type imports so a single codebase typechecks under both majors.

## Background

Vite 8's "epic rolldown merge" retypes plugin hooks against rolldown's types (re-exported from `vite` as the `Rolldown` namespace), which are structurally narrower than rollup's for several interfaces this plugin touches — `PluginContext`, `ModuleInfo`, `OutputBundle` / `OutputChunk`. Runtime behavior is unchanged; the incompatibility is type-only.

The plugin only consumes fields that exist in both rollup and rolldown shapes (`.id`, `.ast`, chunk `.type` / `.fileName` / `.code` / `.dynamicImports` / `.viteMetadata`, and `pluginContext` is an opaque pass-through used for diagnostics). Three narrow casts at assignment sites let the existing rollup-typed imports continue to work under both versions:

- `buildStart`: `pluginContext = this as unknown as PluginContext`
- `moduleParsed`: `info as unknown as ModuleInfo` when forwarding to `unstable_handleModuleParsed`
- `replaceVueRouterPreload(code, bundle as unknown as OutputBundle)`

In `lazy.ts`, `OutputChunk` is intersected with Vite's exported `ChunkMetadata` so `chunk.viteMetadata?.importedCss` typechecks under Vite 8 (which only augments rolldown's `OutputChunk`, not rollup's).

The catalog is bumped to `vite: ^8.0.1` so every example app and the playwright matrix exercise Vite 8 in CI. Vite 7 consumers keep working via the peer range — no migration doc or version bump required, since this is strictly additive.

## Verification

Locally, against this branch:

- `pnpm p:build` ✅ — plugin builds clean on Vite 8 (typecheck + rollup bundle)
- `pnpm p:test` (vitest) ✅ — 6/6 plugin unit tests pass
- `pnpm build` ✅ — all 16 example apps build (react, vue, vue-router, svelte, solid, preact, mui, emotion, tailwind, tailwind4, less, scss, stylus, remix-spa, react-router-spa)
- Flipped the catalog back to `vite: ^7.1.3` and re-ran the full matrix — typecheck, `pnpm p:build`, and `pnpm build` (all 16 apps) all ✅ under Vite 7 as well, confirming dual support.

Against a real production consumer (prodigy-ems/prodigy frontend on Vite 8.0.8 with a locally-patched copy of this plugin): typecheck, `pnpm build`, and the full Cypress component test suite (60/60 across 14 specs) all pass, and the `Content-Security-Policy` meta tag is correctly injected into the built `index.html`.

[Written by Claude]